### PR TITLE
Add Plex auth support

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,10 +9,16 @@ import commandLineArgs from 'command-line-args'
 const optionDefinitions = [
 	{ name: 'ip', type: String },
 	{ name: 'listPath', type: String, multiple: false, defaultOption: true },
+	{ name: 'username', type: String },
+	{ name: 'token', type: String }
 ]
 const options = commandLineArgs(optionDefinitions)
 
-const client = new PlexAPI(options.ip);
+const client = new PlexAPI({
+	hostname : options.ip,
+	username : options.username,
+	token : options.token
+});
 
 // TODO ratings
 
@@ -77,6 +83,11 @@ async function processList(url) {
 		} else {
 			console.warn(`❌ ${listFilm.title} (${listFilm.year})`)
 		}
+	}
+
+	if (!filmKeys.length) {
+		console.warn("Empty film list")
+		return
 	}
 
 	const allCollections = (await client.query(`/library/sections/1/collections`)).MediaContainer.Metadata


### PR DESCRIPTION
Thank you for the project!

When I tried running the import PlexAPI couldn't connect and needed authentication. This change passes in username and auth token (https://support.plex.tv/articles/204059436-finding-an-authentication-token-x-plex-token/) so it can connect to Plex.

I also made a change to not create a Plex collection if the film list is empty. 